### PR TITLE
Update site logo

### DIFF
--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,21 +1,9 @@
-
-<svg width="220" height="60" viewBox="0 0 220 60" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Vardr">
-  <defs>
-    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#C4F0FF"/>
-      <stop offset="100%" stop-color="#7AE0FF"/>
-    </linearGradient>
-  </defs>
-  <!-- Watchtower / signal mark -->
-  <g transform="translate(10,10)">
-    <rect x="0" y="8" width="14" height="32" rx="2" fill="url(#g)"/>
-    <rect x="4" y="0" width="6" height="10" rx="1" fill="url(#g)"/>
-    <circle cx="7" cy="29" r="2" fill="#121417"/>
-    <path d="M18 14 C30 10, 30 38, 18 34" fill="none" stroke="url(#g)" stroke-width="2" stroke-linecap="round"/>
-    <path d="M22 12 C38 8, 38 40, 22 36" fill="none" stroke="url(#g)" stroke-width="2" stroke-linecap="round" opacity="0.6"/>
-  </g>
-  <!-- Wordmark -->
-  <g transform="translate(60,18)" fill="#E6EDF3">
-    <text x="0" y="24" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Ubuntu,Inter,'Helvetica Neue',Arial,sans-serif" font-size="28" font-weight="700" letter-spacing="0.5">Vardr</text>
+<svg width="220" height="80" viewBox="0 0 220 80" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Vardr">
+  <title>Vardr</title>
+  <g fill="none" fill-rule="evenodd">
+    <g transform="translate(10 10)">
+      <circle cx="30" cy="30" r="26" stroke="#79D6F4" stroke-width="8" stroke-linecap="round" stroke-dasharray="220 70"/>
+    </g>
+    <text x="90" y="55" fill="#79D6F4" font-family="'Inter', 'Helvetica Neue', Arial, sans-serif" font-size="42" font-weight="600">Vardr</text>
   </g>
 </svg>


### PR DESCRIPTION
## Summary
- replace the existing SVG logo with the new Vardr mark so the page header displays the updated brand artwork

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d29f481a48832b922ff49e312a979d