### PR TITLE
fix(waitlist): switch to supabase-js upsert to avoid 405/CORS/header issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -285,11 +285,14 @@
     </div>
   </footer>
 
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script>
     document.getElementById('year').textContent = new Date().getFullYear();
 
     const SUPABASE_URL = 'https://tvkgbujmcoctnnqsolxr.supabase.co';
     const ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InR2a2didWptY29jdG5ucXNvbHhyIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTg2NTU2ODAsImV4cCI6MjA3NDIzMTY4MH0.wqP6A1YTFWsMhKPea_z9M6hOXAvGNialHbLAKLg99ds';
+
+    const supabaseClient = window.supabase.createClient(SUPABASE_URL, ANON_KEY);
 
     const forms = document.querySelectorAll('.waitlist-form');
 
@@ -324,27 +327,13 @@
         }
 
         try {
-          const response = await fetch(`${SUPABASE_URL}/rest/v1/waitlist?on_conflict=email`, {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              apikey: ANON_KEY,
-              Authorization: `Bearer ${ANON_KEY}`,
-              Prefer: 'resolution=merge-duplicates, return=representation',
-            },
-            body: JSON.stringify([
-              {
-                email: emailInput.value.trim(),
-              },
-            ]),
-          });
+          const trimmedEmail = emailInput.value.trim();
+          const { error: supabaseError } = await supabaseClient
+            .from('waitlist')
+            .upsert([{ email: trimmedEmail }], { onConflict: 'email' });
 
-          if (!response.ok) {
-            const txt = await response.text(),
-              console.log('FAIL', response.status,txt);
-            alert('Error ' + response.status + ': ' + txt;
-            return;
-            throw new Error(await response.text());
+          if (supabaseError) {
+            throw supabaseError;
           }
 
           form.reset();


### PR DESCRIPTION
## Summary
- load the Supabase JS v2 client from CDN and instantiate it with existing environment constants
- replace the custom REST fetch call with a Supabase upsert to the waitlist table while preserving existing validation and alerts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3ce84c664832bb40a4cec1fbb2586