### PR TITLE
Polish layout and add call-to-action styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,7 @@
           <li><a href="#use-cases">Use Cases</a></li>
           <li><a href="#waitlist">Pricing</a></li>
           <li><a href="#login">Log in</a></li>
+          <li class="nav-cta"><a href="#waitlist">Get Early Access</a></li>
         </ul>
       </nav>
     </div>
@@ -94,11 +95,12 @@
         </svg>
       </div>
       <div class="container">
-        <div class="section-intro">
-          <h2>Track the silence before it sticks.</h2>
-          <p>Vardr watches for quiet signals across the feeds, forums, product telemetry, and customer conversations you care about, pairing quantitative decay with the qualitative stories behind it.</p>
-        </div>
-        <div class="feature-grid">
+        <div class="section-layout">
+          <div class="section-intro">
+            <h2>Track the silence before it sticks.</h2>
+            <p>Vardr watches for quiet signals across the feeds, forums, product telemetry, and customer conversations you care about, pairing quantitative decay with the qualitative stories behind it.</p>
+          </div>
+          <div class="feature-grid">
           <article class="feature-card">
             <span class="icon-medallion icon--reverse" aria-hidden="true">
               <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" focusable="false">
@@ -143,6 +145,7 @@
               <p>See decay trends and act in time with trendlines, benchmarks, and recommended next steps tailored to your goals.</p>
             </div>
           </article>
+          </div>
         </div>
       </div>
       <div class="wave wave-bottom wave-soft" aria-hidden="true">
@@ -159,11 +162,12 @@
         </svg>
       </div>
       <div class="container">
-        <div class="section-intro">
-          <h2>Where silence hurts first.</h2>
-          <p>Creators, product teams, and brands get an early whisper when their signals slip, along with a clear readout of what to fix, who to re-engage, and where to redeploy spend.</p>
-        </div>
-        <div class="case-grid">
+        <div class="section-layout">
+          <div class="section-intro">
+            <h2>Where silence hurts first.</h2>
+            <p>Creators, product teams, and brands get an early whisper when their signals slip, along with a clear readout of what to fix, who to re-engage, and where to redeploy spend.</p>
+          </div>
+          <div class="case-grid">
           <article class="case-card">
             <span class="icon-medallion icon--reverse" aria-hidden="true">
               <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" focusable="false">
@@ -197,6 +201,7 @@
             <h3>Brands</h3>
             <p>Watch competitor buzz fade or rise, then guide spend and strategy with hard evidence of where you’re winning back attention.</p>
           </article>
+          </div>
         </div>
       </div>
       <div class="wave wave-bottom wave-white" aria-hidden="true">

--- a/styles.css
+++ b/styles.css
@@ -146,6 +146,24 @@ input:focus-visible {
   box-shadow: 0 0 0 1px rgba(124, 141, 255, 0.24);
 }
 
+.nav-cta a {
+  color: #ffffff;
+  background-image: linear-gradient(135deg, var(--accent), #5fc9ff 60%, var(--accent-purple));
+  box-shadow: 0 18px 36px rgba(45, 165, 189, 0.32);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-position 0.25s ease;
+  background-size: 140% auto;
+  padding-inline: clamp(20px, 4vw, 28px);
+  font-weight: 700;
+}
+
+.nav-cta a:hover,
+.nav-cta a:focus-visible {
+  color: #ffffff;
+  transform: translateY(-2px);
+  box-shadow: 0 26px 48px rgba(45, 165, 189, 0.36);
+  background-position: right center;
+}
+
 main section {
   position: relative;
   padding-block: clamp(72px, 12vw, 132px);
@@ -156,11 +174,32 @@ main section {
   background: linear-gradient(120deg, rgba(33, 193, 214, 0.16), rgba(124, 141, 255, 0.12)), #ffffff;
 }
 
+.hero::before {
+  content: '';
+  position: absolute;
+  top: -18%;
+  right: -14%;
+  width: clamp(280px, 38vw, 460px);
+  height: clamp(280px, 38vw, 460px);
+  background: radial-gradient(circle at 30% 30%, rgba(33, 193, 214, 0.35), rgba(124, 141, 255, 0));
+  filter: blur(0.5px);
+  opacity: 0.7;
+  z-index: 0;
+}
+
 .hero-grid {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(0, 0.9fr);
   gap: clamp(48px, 8vw, 96px);
   align-items: center;
+  position: relative;
+  z-index: 1;
+}
+
+.hero-copy {
+  display: grid;
+  gap: clamp(18px, 3vw, 28px);
+  max-width: 560px;
 }
 
 .hero-copy h1 {
@@ -174,7 +213,7 @@ main section {
   font-size: clamp(18px, 2.6vw, 22px);
   line-height: 1.7;
   color: var(--muted);
-  max-width: 68ch;
+  max-width: 56ch;
   margin: 0;
 }
 
@@ -198,6 +237,10 @@ main section {
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   gap: 12px;
+}
+
+.hero .waitlist-form {
+  max-width: 480px;
 }
 
 .waitlist-form .form-field {
@@ -261,6 +304,7 @@ main section {
   font-size: 14px;
   color: rgba(27, 35, 48, 0.6);
   letter-spacing: 0.02em;
+  max-width: 48ch;
 }
 
 .hero-art {
@@ -270,6 +314,8 @@ main section {
   display: flex;
   justify-content: center;
   align-items: flex-end;
+  padding: clamp(12px, 2.6vw, 20px);
+  isolation: isolate;
 }
 
 .hero-portrait {
@@ -278,12 +324,35 @@ main section {
   border-radius: 48px;
   overflow: hidden;
   box-shadow: 0 26px 48px rgba(12, 24, 48, 0.38);
+  background: linear-gradient(135deg, rgba(33, 193, 214, 0.12), rgba(124, 141, 255, 0.14));
+  aspect-ratio: 3 / 4;
 }
 
-.hero-portrait-illustration {
-  width: 100%;
-  height: auto;
+.hero-portrait::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   border-radius: inherit;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.28);
+  pointer-events: none;
+}
+
+.hero-portrait img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.hero-art::before {
+  content: '';
+  position: absolute;
+  bottom: 4%;
+  left: 12%;
+  width: clamp(180px, 32vw, 280px);
+  height: clamp(180px, 32vw, 280px);
+  background: radial-gradient(circle, rgba(33, 193, 214, 0.28), rgba(33, 193, 214, 0));
+  filter: blur(60px);
+  z-index: 0;
 }
 
 .hero-wave {
@@ -292,6 +361,7 @@ main section {
   right: -6%;
   width: clamp(160px, 38vw, 240px);
   filter: drop-shadow(0 10px 24px rgba(33, 193, 214, 0.24));
+  z-index: 1;
 }
 
 .section-intro {
@@ -311,10 +381,20 @@ main section {
   color: var(--muted);
 }
 
+.section-layout {
+  display: grid;
+  gap: clamp(32px, 6vw, 72px);
+}
+
+.section-layout .section-intro {
+  margin-bottom: 0;
+}
+
 .feature-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   gap: clamp(24px, 5vw, 40px);
+  grid-auto-rows: 1fr;
 }
 
 .feature-card {
@@ -327,6 +407,9 @@ main section {
   background: rgba(255, 255, 255, 0.92);
   box-shadow: var(--shadow-soft);
   border: 1px solid rgba(124, 141, 255, 0.18);
+  position: relative;
+  overflow: hidden;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
 }
 
 .feature-card h3 {
@@ -339,6 +422,30 @@ main section {
   color: var(--muted);
   font-size: 16px;
   line-height: 1.6;
+}
+
+.feature-card::before {
+  content: '';
+  position: absolute;
+  inset: auto -26% -32% auto;
+  width: 180px;
+  height: 180px;
+  background: radial-gradient(circle at center, rgba(124, 141, 255, 0.28), rgba(124, 141, 255, 0));
+  opacity: 0;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  pointer-events: none;
+}
+
+.feature-card:hover,
+.feature-card:focus-within {
+  transform: translateY(-6px);
+  box-shadow: 0 28px 54px rgba(27, 35, 48, 0.14);
+}
+
+.feature-card:hover::before,
+.feature-card:focus-within::before {
+  opacity: 1;
+  transform: translate3d(-10px, -6px, 0);
 }
 
 .icon-medallion {
@@ -376,6 +483,7 @@ main section {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   gap: clamp(24px, 5vw, 40px);
+  grid-auto-rows: 1fr;
 }
 
 .case-card {
@@ -386,6 +494,9 @@ main section {
   border: 1px solid rgba(124, 141, 255, 0.16);
   display: grid;
   gap: 18px;
+  position: relative;
+  overflow: hidden;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
 }
 
 .case-card h3 {
@@ -412,6 +523,29 @@ main section {
   gap: clamp(24px, 5vw, 36px);
 }
 
+.case-card::before {
+  content: '';
+  position: absolute;
+  inset: auto -28% -36% auto;
+  width: 200px;
+  height: 200px;
+  background: radial-gradient(circle at center, rgba(246, 118, 86, 0.18), rgba(246, 118, 86, 0));
+  opacity: 0;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.case-card:hover,
+.case-card:focus-within {
+  transform: translateY(-6px);
+  box-shadow: 0 28px 54px rgba(27, 35, 48, 0.12);
+}
+
+.case-card:hover::before,
+.case-card:focus-within::before {
+  opacity: 1;
+  transform: translate3d(-12px, -6px, 0);
+}
+
 .how-steps li {
   position: relative;
   padding: 32px 28px 28px;
@@ -421,6 +555,7 @@ main section {
   box-shadow: var(--shadow-soft);
   display: grid;
   gap: 12px;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
 }
 
 .step-badge {
@@ -448,6 +583,12 @@ main section {
   line-height: 1.6;
 }
 
+.how-steps li:hover,
+.how-steps li:focus-within {
+  transform: translateY(-4px);
+  box-shadow: 0 24px 48px rgba(27, 35, 48, 0.12);
+}
+
 .cta {
   background: #ffffff;
   padding-bottom: clamp(96px, 14vw, 148px);
@@ -463,6 +604,33 @@ main section {
   background: linear-gradient(135deg, rgba(214, 236, 255, 0.92), rgba(231, 224, 255, 0.9));
   border: 1px solid rgba(124, 141, 255, 0.22);
   box-shadow: var(--shadow-soft);
+  max-width: 980px;
+  margin: 0 auto;
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.cta-panel::before {
+  content: '';
+  position: absolute;
+  inset: auto -18% -36% auto;
+  width: clamp(220px, 32vw, 320px);
+  height: clamp(220px, 32vw, 320px);
+  background: radial-gradient(circle at center, rgba(33, 193, 214, 0.2), rgba(33, 193, 214, 0));
+  opacity: 0.7;
+  pointer-events: none;
+}
+
+.cta-panel::after {
+  content: '';
+  position: absolute;
+  inset: -18% auto auto -22%;
+  width: clamp(260px, 36vw, 360px);
+  height: clamp(260px, 36vw, 360px);
+  background: radial-gradient(circle at center, rgba(124, 141, 255, 0.22), rgba(124, 141, 255, 0));
+  opacity: 0.6;
+  pointer-events: none;
 }
 
 .cta-copy h2 {
@@ -470,8 +638,15 @@ main section {
   font-size: clamp(28px, 5vw, 40px);
 }
 
+.cta-copy {
+  display: grid;
+  gap: 12px;
+  position: relative;
+  z-index: 1;
+}
+
 .cta-copy p {
-  margin: 0 0 12px;
+  margin: 0;
   color: var(--ink-soft);
   line-height: 1.6;
 }
@@ -479,6 +654,11 @@ main section {
 .cta-note {
   font-size: 15px;
   color: rgba(27, 35, 48, 0.58);
+}
+
+.cta-panel form {
+  position: relative;
+  z-index: 1;
 }
 
 .site-footer {
@@ -580,6 +760,13 @@ main section {
     width: min(70%, 380px);
   }
 
+  .hero::before {
+    top: -28%;
+    right: -32%;
+    width: clamp(240px, 60vw, 380px);
+    height: clamp(240px, 60vw, 380px);
+  }
+
   .hero-copy {
     text-align: left;
   }
@@ -593,9 +780,19 @@ main section {
 
   .nav-list {
     font-size: 14px;
-    gap: 20px;
+    gap: 16px;
     flex-basis: 100%;
-    justify-content: flex-end;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .nav-cta {
+    flex-basis: 100%;
+  }
+
+  .nav-cta a {
+    width: 100%;
+    justify-content: center;
   }
 
   .waitlist-form {
@@ -641,6 +838,23 @@ main section {
 
   .footer-links {
     gap: 16px;
+  }
+}
+
+@media (min-width: 960px) {
+  .section-layout {
+    grid-template-columns: minmax(0, 0.85fr) minmax(0, 1.15fr);
+    align-items: start;
+  }
+
+  .section-layout .section-intro {
+    position: sticky;
+    top: clamp(88px, 12vw, 140px);
+    margin-bottom: 0;
+  }
+
+  .section-layout .section-intro p {
+    max-width: 48ch;
   }
 }
 


### PR DESCRIPTION
## Summary
- add a dedicated "Get Early Access" button in the navigation and polish the hero spacing for a more structured first impression
- introduce reusable section layout wrappers that keep copy pinned alongside features and use cases while adding interactive card hover states
- refine CTA panel visuals with layered gradients and ensure all cards and steps share consistent depth cues

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d3ffcc5aa4832ba37297f809fd8e65