### PR TITLE
fix: stabilize home header condensed state

### DIFF
--- a/scripts/header.js
+++ b/scripts/header.js
@@ -11,88 +11,548 @@ const drawerLinks = mobileDrawer?.querySelectorAll('a');
 const focusableSelector = 'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 const condenseMedia = window.matchMedia('(max-width: 768px)');
-let headerMetrics = { height: 0, bottom: 0 };
-let isHeaderCondensed = false;
-let lastScrollY = window.scrollY;
-let scrollDirection = 'down';
+
+const DEBUG_QUERY_KEY = 'debugHeader';
+const DEBUG_STORAGE_KEY = 'vardr:debugHeader';
+const DEBUG_ATTRIBUTE = 'data-debug-header';
+const HEADER_STATE = {
+  EXPANDED: 'expanded',
+  CONDENSED: 'condensed'
+};
+
+class CondensedHeaderController {
+  constructor(header, pill, options = {}) {
+    this.header = header;
+    this.pill = pill;
+    this.mediaQuery = options.mediaQuery;
+    this.onMobileExit = typeof options.onMobileExit === 'function' ? options.onMobileExit : () => {};
+    this.debugEnabled = false;
+    this.debugUI = null;
+    this.debugStyle = null;
+    this.isCondensed = false;
+    this.scrollDirection = 'down';
+    this.lastScrollPosition = window.scrollY + (window.visualViewport?.offsetTop || 0);
+    this.lastReason = 'init';
+    this.lastMetrics = {
+      scrollY: window.scrollY,
+      direction: this.scrollDirection,
+      viewportOffsetTop: window.visualViewport?.offsetTop || 0,
+      viewportWidth:
+        window.visualViewport?.width || document.documentElement.clientWidth || window.innerWidth || 0,
+      headerBottom: 0,
+      pillTop: 0,
+      delta: 0,
+      enterBuffer: 0,
+      exitBuffer: 0
+    };
+    this.currentBuffers = { enter: 0, exit: 0 };
+    this.rafId = null;
+    this.mutationObserver = null;
+    this.resizeObserver = null;
+    this.lastLogTime = 0;
+
+    this.handleScroll = this.handleScroll.bind(this);
+    this.handleResize = this.handleResize.bind(this);
+    this.handleViewportChange = this.handleViewportChange.bind(this);
+    this.handleMediaChange = this.handleMediaChange.bind(this);
+    this.handleResizeEntries = this.handleResizeEntries.bind(this);
+  }
+
+  init() {
+    this.debugEnabled = this.resolveDebugFlag();
+    this.toggleDebugAttribute(this.debugEnabled);
+
+    if (this.debugEnabled) {
+      this.debugUI = this.createDebugInterface();
+      this.auditMutations();
+      this.logSample('init', this.lastMetrics, 'controller-initialised', HEADER_STATE.EXPANDED);
+    }
+
+    window.addEventListener('scroll', this.handleScroll, { passive: true });
+    window.addEventListener('resize', this.handleResize, { passive: true });
+
+    if (window.visualViewport) {
+      window.visualViewport.addEventListener('scroll', this.handleViewportChange, { passive: true });
+      window.visualViewport.addEventListener('resize', this.handleViewportChange, { passive: true });
+    }
+
+    if (this.mediaQuery) {
+      if (typeof this.mediaQuery.addEventListener === 'function') {
+        this.mediaQuery.addEventListener('change', this.handleMediaChange);
+      } else if (typeof this.mediaQuery.addListener === 'function') {
+        this.mediaQuery.addListener(this.handleMediaChange);
+      }
+      this.handleMediaChange(this.mediaQuery);
+    }
+
+    if ('ResizeObserver' in window) {
+      this.resizeObserver = new ResizeObserver(this.handleResizeEntries);
+      this.resizeObserver.observe(this.header);
+      this.resizeObserver.observe(this.pill);
+    }
+
+    this.scheduleMeasure();
+  }
+
+  resolveDebugFlag() {
+    let fromStorage = false;
+    try {
+      fromStorage = window.localStorage.getItem(DEBUG_STORAGE_KEY) === '1';
+    } catch (error) {
+      fromStorage = false;
+    }
+
+    let resolved = fromStorage;
+    try {
+      const params = new URLSearchParams(window.location.search);
+      if (params.has(DEBUG_QUERY_KEY)) {
+        const value = params.get(DEBUG_QUERY_KEY);
+        const enable = value === '1' || value === 'true';
+        resolved = enable;
+        try {
+          if (enable) {
+            window.localStorage.setItem(DEBUG_STORAGE_KEY, '1');
+          } else {
+            window.localStorage.removeItem(DEBUG_STORAGE_KEY);
+          }
+        } catch (storageError) {
+          // Ignore storage errors (private mode, etc.)
+        }
+      }
+    } catch (error) {
+      // Ignore URL parsing issues
+    }
+
+    return resolved;
+  }
+
+  toggleDebugAttribute(active) {
+    if (!document.documentElement) {
+      return;
+    }
+
+    if (active) {
+      document.documentElement.setAttribute(DEBUG_ATTRIBUTE, 'true');
+    } else {
+      document.documentElement.removeAttribute(DEBUG_ATTRIBUTE);
+    }
+  }
+
+  createDebugInterface() {
+    const style = document.createElement('style');
+    style.textContent = `
+      [${DEBUG_ATTRIBUTE}="true"] .header-debug-overlay {
+        position: fixed;
+        inset: 16px 16px auto auto;
+        min-width: 220px;
+        font-family: ui-monospace, SFMono-Regular, SFMono, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+        font-size: 12px;
+        line-height: 1.4;
+        color: #0b1f33;
+        background: rgba(255, 255, 255, 0.94);
+        border: 1px solid rgba(11, 31, 51, 0.18);
+        border-radius: 8px;
+        padding: 12px;
+        box-shadow: 0 12px 24px rgba(7, 30, 63, 0.18);
+        z-index: 9999;
+        pointer-events: none;
+      }
+
+      [${DEBUG_ATTRIBUTE}="true"] .header-debug-overlay h2 {
+        margin: 0 0 8px;
+        font-size: 12px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      [${DEBUG_ATTRIBUTE}="true"] .header-debug-overlay dl {
+        margin: 0;
+        display: grid;
+        grid-template-columns: auto 1fr;
+        gap: 4px 12px;
+      }
+
+      [${DEBUG_ATTRIBUTE}="true"] .header-debug-overlay dt {
+        font-weight: 600;
+        color: rgba(11, 31, 51, 0.7);
+      }
+
+      [${DEBUG_ATTRIBUTE}="true"] .header-debug-overlay dd {
+        margin: 0;
+        text-align: right;
+      }
+
+      [${DEBUG_ATTRIBUTE}="true"] .header-debug-sentinel {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        height: 1px;
+        pointer-events: none;
+        z-index: 9998;
+        will-change: transform;
+      }
+
+      [${DEBUG_ATTRIBUTE}="true"] .header-debug-sentinel::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        border-top: 1px dashed rgba(111, 66, 193, 0.75);
+      }
+
+      [${DEBUG_ATTRIBUTE}="true"] .header-debug-sentinel--pill::before {
+        border-color: rgba(33, 193, 214, 0.8);
+      }
+    `;
+    document.head.appendChild(style);
+
+    const overlay = document.createElement('div');
+    overlay.className = 'header-debug-overlay';
+    overlay.innerHTML = `
+      <h2>Header Debug</h2>
+      <dl>
+        <dt>scrollY</dt><dd data-debug-field="scrollY">0</dd>
+        <dt>Direction</dt><dd data-debug-field="direction">down</dd>
+        <dt>ViewportY</dt><dd data-debug-field="viewportOffset">0</dd>
+        <dt>ViewportW</dt><dd data-debug-field="viewportWidth">0</dd>
+        <dt>Header ⬇︎</dt><dd data-debug-field="headerBottom">0</dd>
+        <dt>Pill ⬆︎</dt><dd data-debug-field="pillTop">0</dd>
+        <dt>Δ (pill-header)</dt><dd data-debug-field="delta">0</dd>
+        <dt>Buffers</dt><dd data-debug-field="buffers">0 / 0</dd>
+        <dt>State</dt><dd data-debug-field="state">expanded</dd>
+        <dt>Reason</dt><dd data-debug-field="reason">init</dd>
+      </dl>
+    `;
+
+    const fields = overlay.querySelectorAll('[data-debug-field]');
+    const fieldMap = {};
+    fields.forEach((field) => {
+      const key = field.getAttribute('data-debug-field');
+      if (key) {
+        fieldMap[key] = field;
+      }
+    });
+
+    const headerSentinel = document.createElement('div');
+    headerSentinel.className = 'header-debug-sentinel header-debug-sentinel--header';
+
+    const pillSentinel = document.createElement('div');
+    pillSentinel.className = 'header-debug-sentinel header-debug-sentinel--pill';
+
+    document.body.appendChild(overlay);
+    document.body.appendChild(headerSentinel);
+    document.body.appendChild(pillSentinel);
+
+    this.debugStyle = style;
+
+    return {
+      overlay,
+      fields: fieldMap,
+      headerSentinel,
+      pillSentinel
+    };
+  }
+
+  auditMutations() {
+    if (!('MutationObserver' in window) || !this.debugEnabled) {
+      return;
+    }
+
+    this.mutationObserver = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
+          const condensed = this.header.classList.contains('is-condensed');
+          this.logSample(
+            'mutation',
+            this.lastMetrics,
+            condensed ? 'class-added-is-condensed' : 'class-removed-is-condensed',
+            condensed ? HEADER_STATE.CONDENSED : HEADER_STATE.EXPANDED
+          );
+        }
+      });
+    });
+
+    this.mutationObserver.observe(this.header, { attributes: true, attributeFilter: ['class'] });
+  }
+
+  handleResizeEntries(entries) {
+    if (!entries?.length) {
+      return;
+    }
+
+    if (this.debugEnabled) {
+      this.logSample(
+        'resize-observer',
+        this.lastMetrics,
+        'resize-observer-notified',
+        this.isCondensed ? HEADER_STATE.CONDENSED : HEADER_STATE.EXPANDED
+      );
+    }
+
+    this.scheduleMeasure();
+  }
+
+  handleScroll() {
+    this.updateScrollDirection();
+    this.scheduleMeasure();
+  }
+
+  handleResize() {
+    this.scheduleMeasure();
+  }
+
+  handleViewportChange() {
+    this.updateScrollDirection();
+    this.scheduleMeasure();
+  }
+
+  handleMediaChange(event) {
+    const matches = typeof event?.matches === 'boolean' ? event.matches : this.mediaQuery?.matches;
+    if (!matches) {
+      if (this.isCondensed) {
+        this.setCondensed(false, 'media-query-exit', this.lastMetrics);
+      }
+      this.onMobileExit();
+    }
+
+    if (this.debugEnabled) {
+      this.logSample(
+        'media-change',
+        this.lastMetrics,
+        matches ? 'media-query-enter' : 'media-query-exit',
+        this.isCondensed ? HEADER_STATE.CONDENSED : HEADER_STATE.EXPANDED
+      );
+    }
+
+    this.scheduleMeasure();
+  }
+
+  updateScrollDirection() {
+    const viewportOffset = window.visualViewport?.offsetTop || 0;
+    const position = window.scrollY + viewportOffset;
+    const delta = position - this.lastScrollPosition;
+    const epsilon = 0.5;
+
+    if (Math.abs(delta) > epsilon) {
+      const nextDirection = delta < 0 ? 'up' : 'down';
+      if (nextDirection !== this.scrollDirection) {
+        this.scrollDirection = nextDirection;
+        if (this.debugEnabled) {
+          this.logSample(
+            'direction',
+            this.lastMetrics,
+            `direction-${nextDirection}`,
+            this.isCondensed ? HEADER_STATE.CONDENSED : HEADER_STATE.EXPANDED
+          );
+        }
+      }
+    }
+
+    this.lastScrollPosition = position;
+  }
+
+  getEnterBuffer(headerHeight) {
+    const minBuffer = 24;
+    return Math.max(minBuffer, headerHeight * 0.35);
+  }
+
+  getExitBuffer(headerHeight) {
+    const minBuffer = 48;
+    return Math.max(minBuffer, headerHeight * 0.85);
+  }
+
+  scheduleMeasure() {
+    if (this.rafId !== null) {
+      return;
+    }
+
+    this.rafId = window.requestAnimationFrame(() => {
+      this.rafId = null;
+      this.measure();
+    });
+  }
+
+  measure() {
+    const viewportOffset = window.visualViewport?.offsetTop || 0;
+    const viewportWidth =
+      window.visualViewport?.width || document.documentElement.clientWidth || window.innerWidth || 0;
+    const headerRect = this.header.getBoundingClientRect();
+    const pillRect = this.pill.getBoundingClientRect();
+
+    const headerBottom = headerRect.bottom;
+    const pillTop = pillRect.top;
+    const delta = pillTop - headerBottom;
+    const enterBuffer = this.getEnterBuffer(headerRect.height || 0);
+    const exitBuffer = this.getExitBuffer(headerRect.height || 0);
+
+    const metrics = {
+      scrollY: window.scrollY,
+      direction: this.scrollDirection,
+      viewportOffsetTop: viewportOffset,
+      viewportWidth,
+      headerBottom,
+      pillTop,
+      delta,
+      enterBuffer,
+      exitBuffer
+    };
+
+    this.currentBuffers = { enter: enterBuffer, exit: exitBuffer };
+
+    const mediaMatches = this.mediaQuery ? this.mediaQuery.matches : true;
+    let reason = '';
+
+    if (!mediaMatches) {
+      if (this.isCondensed) {
+        reason = 'media-query-gate';
+        this.setCondensed(false, reason, metrics);
+      }
+      this.updateDebugOverlay(metrics, reason || this.lastReason);
+      this.logSample('measure', metrics, reason || this.lastReason, this.isCondensed ? HEADER_STATE.CONDENSED : HEADER_STATE.EXPANDED);
+      return;
+    }
+
+    if (window.scrollY <= 0) {
+      if (this.isCondensed) {
+        reason = 'returned-to-top';
+        this.setCondensed(false, reason, metrics);
+      }
+      this.updateDebugOverlay(metrics, reason || this.lastReason);
+      this.logSample('measure', metrics, reason || this.lastReason, HEADER_STATE.EXPANDED);
+      return;
+    }
+
+    if (!this.isCondensed) {
+      if (this.scrollDirection === 'up' && delta <= -enterBuffer) {
+        reason = `enter (Δ ${Math.round(delta)} <= -${Math.round(enterBuffer)})`;
+        this.setCondensed(true, reason, metrics);
+      }
+    } else if (this.scrollDirection === 'down' && delta >= exitBuffer) {
+      reason = `exit (Δ ${Math.round(delta)} >= ${Math.round(exitBuffer)})`;
+      this.setCondensed(false, reason, metrics);
+    }
+
+    this.updateDebugOverlay(metrics, reason || this.lastReason);
+    this.logSample('measure', metrics, reason || this.lastReason, this.isCondensed ? HEADER_STATE.CONDENSED : HEADER_STATE.EXPANDED);
+  }
+
+  setCondensed(shouldCondense, reason, metrics) {
+    const target = Boolean(shouldCondense);
+    if (target === this.isCondensed) {
+      this.lastReason = reason || this.lastReason;
+      return;
+    }
+
+    this.isCondensed = target;
+    this.header.classList.toggle('is-condensed', target);
+    this.lastReason = reason || (target ? 'condensed' : 'expanded');
+
+    if (this.debugEnabled) {
+      const state = target ? HEADER_STATE.CONDENSED : HEADER_STATE.EXPANDED;
+      this.logSample('state-change', metrics || this.lastMetrics, this.lastReason, state);
+    }
+
+    this.scheduleMeasure();
+  }
+
+  updateDebugOverlay(metrics, reason) {
+    this.lastMetrics = metrics;
+
+    if (!this.debugEnabled || !this.debugUI) {
+      return;
+    }
+
+    const state = this.isCondensed ? HEADER_STATE.CONDENSED : HEADER_STATE.EXPANDED;
+    const fields = this.debugUI.fields;
+
+    if (fields.scrollY) {
+      fields.scrollY.textContent = `${Math.round(metrics.scrollY)}`;
+    }
+    if (fields.direction) {
+      fields.direction.textContent = metrics.direction;
+    }
+    if (fields.viewportOffset) {
+      fields.viewportOffset.textContent = `${Math.round(metrics.viewportOffsetTop)}`;
+    }
+    if (fields.viewportWidth) {
+      fields.viewportWidth.textContent = `${Math.round(metrics.viewportWidth)}`;
+    }
+    if (fields.headerBottom) {
+      fields.headerBottom.textContent = `${Math.round(metrics.headerBottom)}`;
+    }
+    if (fields.pillTop) {
+      fields.pillTop.textContent = `${Math.round(metrics.pillTop)}`;
+    }
+    if (fields.delta) {
+      fields.delta.textContent = `${Math.round(metrics.delta)}`;
+    }
+    if (fields.buffers) {
+      fields.buffers.textContent = `${Math.round(metrics.enterBuffer)} / ${Math.round(metrics.exitBuffer)}`;
+    }
+    if (fields.state) {
+      fields.state.textContent = state;
+    }
+    if (fields.reason) {
+      fields.reason.textContent = reason;
+    }
+
+    const offset = metrics.viewportOffsetTop || 0;
+    const headerY = Math.round(metrics.headerBottom + offset);
+    const pillY = Math.round(metrics.pillTop + offset);
+
+    if (this.debugUI.headerSentinel) {
+      this.debugUI.headerSentinel.style.transform = `translate3d(0, ${headerY}px, 0)`;
+    }
+    if (this.debugUI.pillSentinel) {
+      this.debugUI.pillSentinel.style.transform = `translate3d(0, ${pillY}px, 0)`;
+    }
+  }
+
+  logSample(phase, metrics, reason, state) {
+    if (!this.debugEnabled) {
+      return;
+    }
+
+    const now = performance.now();
+    const throttle = phase === 'measure';
+    if (throttle && now - this.lastLogTime < 120) {
+      return;
+    }
+
+    if (throttle) {
+      this.lastLogTime = now;
+    }
+
+    const timestamp = new Date().toISOString();
+    console.groupCollapsed(`[header-debug] ${phase} @ ${timestamp}`);
+    console.log('state', {
+      state,
+      reason,
+      direction: this.scrollDirection,
+      condensed: this.isCondensed
+    });
+    if (metrics) {
+      console.log('metrics', {
+        scrollY: Math.round(metrics.scrollY),
+        direction: metrics.direction,
+        viewportOffsetTop: Math.round(metrics.viewportOffsetTop),
+        viewportWidth: Math.round(metrics.viewportWidth),
+        headerBottom: Math.round(metrics.headerBottom),
+        pillTop: Math.round(metrics.pillTop),
+        delta: Math.round(metrics.delta),
+        enterBuffer: Math.round(metrics.enterBuffer),
+        exitBuffer: Math.round(metrics.exitBuffer)
+      });
+    }
+    if (this.currentBuffers) {
+      console.log('buffers', this.currentBuffers);
+    }
+    console.groupEnd();
+  }
+}
+
 let drawerOpen = false;
 let lastFocusedElement = null;
-
-const refreshObserver = () => {
-  if (!siteHeader) {
-    headerMetrics = { height: 0, bottom: 0 };
-    return;
-  }
-
-  const rect = siteHeader.getBoundingClientRect();
-  headerMetrics = {
-    height: rect.height,
-    bottom: rect.bottom
-  };
-};
-
-const setCondensed = (shouldCondense) => {
-  if (!siteHeader) {
-    return;
-  }
-
-  const targetState = Boolean(shouldCondense) && condenseMedia.matches;
-  if (targetState === isHeaderCondensed) {
-    return;
-  }
-
-  isHeaderCondensed = targetState;
-  siteHeader.classList.toggle('is-condensed', targetState);
-  refreshObserver();
-  window.requestAnimationFrame(refreshObserver);
-};
-
-const evaluateCondensedState = () => {
-  if (!siteHeader || !pillSection) {
-    return;
-  }
-
-  if (!condenseMedia.matches) {
-    setCondensed(false);
-    return;
-  }
-
-  if (window.scrollY <= 0) {
-    setCondensed(false);
-    return;
-  }
-
-  if (!headerMetrics.height) {
-    refreshObserver();
-  }
-
-  const pillRect = pillSection.getBoundingClientRect();
-  const { bottom: headerBottom, height: headerHeight } = headerMetrics;
-  const enterBuffer = Math.max(12, headerHeight * 0.2);
-  const exitBuffer = Math.max(headerHeight, 32);
-
-  if (!isHeaderCondensed) {
-    if (scrollDirection === 'up' && pillRect.bottom >= headerBottom + enterBuffer) {
-      setCondensed(true);
-    }
-    return;
-  }
-
-  if (scrollDirection === 'down' && pillRect.bottom <= headerBottom - exitBuffer) {
-    setCondensed(false);
-  }
-};
-
-const updateScrollDirection = () => {
-  const currentY = window.scrollY;
-  const nextDirection = currentY < lastScrollY ? 'up' : 'down';
-
-  if (nextDirection !== scrollDirection) {
-    scrollDirection = nextDirection;
-  }
-
-  lastScrollY = currentY;
-};
 
 const updateMenuToggleState = (open) => {
   if (!menuToggle) {
@@ -242,40 +702,9 @@ const bindDrawerEvents = () => {
 
 if (siteHeader && pillSection) {
   bindDrawerEvents();
-  refreshObserver();
-  evaluateCondensedState();
-
-  window.addEventListener(
-    'scroll',
-    () => {
-      updateScrollDirection();
-      evaluateCondensedState();
-    },
-    { passive: true }
-  );
-
-  const handleMediaChange = (event) => {
-    if (!event.matches) {
-      setCondensed(false);
-      closeDrawer();
-    }
-
-    refreshObserver();
-    evaluateCondensedState();
-  };
-
-  if (typeof condenseMedia.addEventListener === 'function') {
-    condenseMedia.addEventListener('change', handleMediaChange);
-  } else if (typeof condenseMedia.addListener === 'function') {
-    condenseMedia.addListener(handleMediaChange);
-  }
-
-  window.addEventListener(
-    'resize',
-    () => {
-      refreshObserver();
-      evaluateCondensedState();
-    },
-    { passive: true }
-  );
+  const headerController = new CondensedHeaderController(siteHeader, pillSection, {
+    mediaQuery: condenseMedia,
+    onMobileExit: closeDrawer
+  });
+  headerController.init();
 }


### PR DESCRIPTION
## Summary
- add a home-page-only `debugHeader` flag that persists to localStorage and decorates the DOM for debug sessions
- surface overlay instrumentation, telemetry, and sentinels to inspect header and pill geometry while debugging
- replace the condensed header logic with a buffered scroll state machine that respects direction and viewport offsets

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d548597a3c832bb8376040ade078d9