### PR TITLE
fix: rebalance audience pill spacing with intrinsic columns

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,13 +132,7 @@
     <section class="hero" id="top">
       <div class="container hero-grid">
         <div class="hero-copy">
-          <p id="audience-pill" class="audience-pill" aria-label="Audience tags">
-            <span class="audience-pill__token">FOR CREATORS</span>
-            <span class="audience-pill__token">·</span>
-            <span class="audience-pill__token">PMS</span>
-            <span class="audience-pill__token">·</span>
-            <span class="audience-pill__token">MARKETERS</span>
-          </p>
+          <p id="audience-pill" class="audience-pill" aria-label="Audience tags"><span class="audience-pill__token">FOR CREATORS</span><span class="audience-pill__token">·</span><span class="audience-pill__token">PMS</span><span class="audience-pill__token">·</span><span class="audience-pill__token">MARKETERS</span></p>
           <h1>Because what’s missing, matters.</h1>
           <p class="hero-sub">Vardr quietly tracks when attention fades—surfacing the drop-offs, missed mentions, and low-signal plateaus your dashboards never flag.</p>
           <p class="hero-sub">Our reverse monitoring engine assembles the context investors care about: velocity of decay, channels at risk, and the leading indicators that let teams course-correct with confidence.</p>

--- a/styles.css
+++ b/styles.css
@@ -453,20 +453,22 @@ main section {
 }
 
 .audience-pill {
-  display: inline-flex;
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: max-content;
   align-items: center;
   justify-content: space-between;
-  gap: 0;
   padding: 8px 16px;
   border-radius: 999px;
   background: rgba(124, 141, 255, 0.12);
   color: #4f5a9f;
-  font-size: clamp(11px, 1.85vw, 13px);
+  font-size: clamp(10px, calc(0.48rem + 0.4vw), 13px);
   font-weight: 700;
   letter-spacing: 0.16em;
   text-transform: uppercase;
-  width: min(100%, 420px);
-  flex-wrap: nowrap;
+  width: 100%;
+  max-width: 520px;
+  margin: 0 auto;
   white-space: nowrap;
 }
 
@@ -474,8 +476,8 @@ main section {
   display: flex;
   align-items: center;
   justify-content: center;
-  flex: 1 1 0;
   min-width: 0;
+  text-align: center;
 }
 
 .waitlist-form {


### PR DESCRIPTION
## Summary
- change the home page audience pill to a max-content grid so each token keeps its natural width while gaps expand evenly
- adjust layout sizing to prevent overflow by using a wider max-width and updated font-size clamp

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6709a4478832b8d8875d9acad29fe